### PR TITLE
added Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'http://rubygems.org'
+
+gem 'sprockets', '~>1.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,10 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    sprockets (1.0.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sprockets (~> 1.0.2)


### PR DESCRIPTION
I had trouble running the rake task with Sprockets 2.0.3 (see error log below, seems like Secretary doesn't exist in Sprockets >= 2.0 anymore). fixed by using older Sprockets. added Gemfile to make it clear which Sprocket version is required. 

rake
(in /Users/paul/travis-shopify/liquid.js)
Building liquid.js...
rake aborted!
uninitialized constant Sprockets::Secretary
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:2482:in `const_missing'
/Users/paul/travis-shopify/liquid.js/Rakefile:36:in`block in <top (required)>'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:634:in `call'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:634:in`block in execute'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:629:in `each'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:629:in`execute'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:595:in `block in invoke_with_call_chain'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/monitor.rb:201:in`mon_synchronize'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:588:in `invoke_with_call_chain'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:605:in`block in invoke_prerequisites'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:602:in `each'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:602:in`invoke_prerequisites'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:594:in `block in invoke_with_call_chain'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/monitor.rb:201:in`mon_synchronize'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:588:in `invoke_with_call_chain'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:581:in`invoke'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:2041:in `invoke_task'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:2019:in`block (2 levels) in top_level'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:2019:in `each'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:2019:in`block in top_level'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:2058:in `standard_exception_handling'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:2013:in`top_level'
/Users/paul/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/rake.rb:1992:in `run'
/Users/paul/.rbenv/versions/1.9.2-p290/bin/rake:31:in`<main>'
