### PR TITLE
Fix bug in Context.js

### DIFF
--- a/source/context.js
+++ b/source/context.js
@@ -191,8 +191,8 @@ Liquid.Context = Class.extend({
             else { object  = object[pos]; }
           }
           // Some special cases. If no key with the same name was found we interpret following calls
-          // as commands and call them on the current object
-          else if( typeof(object[part]) == 'function' && ['length', 'size', 'first', 'last'].include(part) ) {
+          // as commands and call them on the current object if it exists
+          else if( object && typeof(object[part]) == 'function' && ['length', 'size', 'first', 'last'].include(part) ) {
             object = object[part].apply(part);
             if('toLiquid' in object){ object = object.toLiquid(); }
           }

--- a/test/tests.js
+++ b/test/tests.js
@@ -369,6 +369,14 @@ var Tests = (function() {
       assertEqual("TRUE",  render("{% unless 1 < 1 %}TRUE{% else %}FALSE{% endunless %}"))
       assertEqual("FALSE", render("{% unless 1 <= 1 %}TRUE{% else %}FALSE{% endunless %}"))
       assertEqual("FALSE", render("{% unless 1 >= 1 %}TRUE{% else %}FALSE{% endunless %}"))
+    },
+
+    note4: "Testing context...",
+
+    "{{ collection['missing_key'].value }}": function() {
+      // TODO Consider using a Context object directly instead, calling variable on it directly
+      assertEqual("", render("{{ collection['missing_key'].value }}"))
+      assertEqual("", render("{{ collection['missing_key'].value }}", {collection: {}}))
     }
   }
 })();


### PR DESCRIPTION
I found a bug in the Context class when its trying to look up a missing key in a collection get the return value from it, i.e. "{{ collection[missing_key].value }}"; this should return an empty string but generating an error.  I've included a test that catches this and the fix.

Thanks,
\Peter
