### PR TITLE
Fixed Bug in Liquid.Context.variable

### DIFF
--- a/source/context.js
+++ b/source/context.js
@@ -1,4 +1,3 @@
-
 Liquid.Context = Class.extend({
 
   init: function(assigns, registers, rethrowErrors) {
@@ -185,7 +184,7 @@ Liquid.Context = Class.extend({
           }
           // Array
           else if( (/^\d+$/).test(part) ) {
-            pos = parseInt(part);
+            var pos = parseInt(part);
             if( typeof(object[pos]) == 'function') { object[pos] = object[pos].apply(self); }
             if(typeof(object[pos]) == 'object' && typeof(object[pos]) == 'object' && ('toLiquid' in object[pos])) { object = object[pos].toLiquid(); }
             else { object  = object[pos]; }
@@ -199,7 +198,7 @@ Liquid.Context = Class.extend({
           // No key was present with the desired value and it wasn't one of the directly supported
           // keywords either. The only thing we got left is to return nil
           else {
-            return null;
+            return object = null;
           }
           if(typeof(object) == 'object' && ('setContext' in object)){ object.setContext(self); }
         }


### PR DESCRIPTION
This fixes an issue where attempting to access a null property on an object would return the parent object

There is also a second issue with a missing var, also in Liquid.Context.variable, this fix means that all the comments regarding pos can be removed...

Sorry about the spammy changes, I'm new to this whole git / gollum thing, didn't realize I could propose my changes online without needing to install git
