### PR TITLE
Fixes `for` loop error when using limit or offset

### DIFF
--- a/source/default_tags.js
+++ b/source/default_tags.js
@@ -231,7 +231,7 @@ Liquid.Template.registerTag( 'for', Liquid.Block.extend({
       if(attMatchs) {
         attMatchs.each(function(pair){
           pair = pair.split(":");
-          this.attributes.set[pair[0].strip()] = pair[1].strip();
+          this.attributes[pair[0].strip()] = pair[1].strip();
         }, this);
       }
     } else {


### PR DESCRIPTION
Don't use undefined set method when setting for tag attributes. Instead directly define attributes object properties.
