### PR TITLE
Fix for contains conditional

### DIFF
--- a/source/condition.js
+++ b/source/condition.js
@@ -72,7 +72,7 @@ Liquid.Condition.operators = {
   '<=': function(l,r) { return (l <= r); },
   '>=': function(l,r) { return (l >= r); },
 
-  'contains': function(l,r) { return l.include(r); },
+  'contains': function(l,r) { return l.match(r); },
   // HACK Apply from Liquid.extensions.object; extending Object sad. 
   //'hasKey': function(l,r) { return l.hasKey(r); }
   'hasKey':   function(l,r) { return Liquid.extensions.object.hasKey.call(l, r); },

--- a/test/tests.js
+++ b/test/tests.js
@@ -328,6 +328,7 @@ var Tests = (function() {
       assertEqual("",     render("{% if 1 < 1 %}TRUE{% endif %}"))
       assertEqual("TRUE", render("{% if 1 <= 1 %}TRUE{% endif %}"))
       assertEqual("TRUE", render("{% if 1 >= 1 %}TRUE{% endif %}"))
+      assertEqual("TRUE", render("{% if 'Test' contains 'T' %}TRUE{% endif %}"))
       // Testing else as well...
       assertEqual("TRUE", render("{% if true %}TRUE{% else %}FALSE{% endif %}"))
       assertEqual("TRUE", render("{% if 1 == 1 %}TRUE{% else %}FALSE{% endif %}"))
@@ -336,6 +337,7 @@ var Tests = (function() {
       assertEqual("FALSE",render("{% if 1 < 1 %}TRUE{% else %}FALSE{% endif %}"))
       assertEqual("TRUE", render("{% if 1 <= 1 %}TRUE{% else %}FALSE{% endif %}"))
       assertEqual("TRUE", render("{% if 1 >= 1 %}TRUE{% else %}FALSE{% endif %}"))
+      assertEqual("TRUE", render("{% if 'Test' contains 'T' %}TRUE{% else %}FALSE{% endif %}"))
     },
 
     "{% ifchanged %}{% endifchanged %}": function() {
@@ -361,6 +363,7 @@ var Tests = (function() {
       assertEqual("TRUE", render("{% unless 1 < 1 %}TRUE{% endunless %}"))
       assertEqual("",     render("{% unless 1 <= 1 %}TRUE{% endunless %}"))
       assertEqual("",     render("{% unless 1 >= 1 %}TRUE{% endunless %}"))
+      assertEqual("", render("{% unless 'Test' contains 'T' %}TRUE{% endunless %}"))
       // Testing else as well...
       assertEqual("FALSE", render("{% unless true %}TRUE{% else %}FALSE{% endunless %}"))
       assertEqual("FALSE", render("{% unless 1 == 1 %}TRUE{% else %}FALSE{% endunless %}"))
@@ -369,6 +372,7 @@ var Tests = (function() {
       assertEqual("TRUE",  render("{% unless 1 < 1 %}TRUE{% else %}FALSE{% endunless %}"))
       assertEqual("FALSE", render("{% unless 1 <= 1 %}TRUE{% else %}FALSE{% endunless %}"))
       assertEqual("FALSE", render("{% unless 1 >= 1 %}TRUE{% else %}FALSE{% endunless %}"))
+      assertEqual("FALSE", render("{% unless 'Test' contains 'T' %}TRUE{% else %}FALSE{% endunless %}"))
     },
 
     note4: "Testing context...",


### PR DESCRIPTION
Object has no method `include`, use `match` instead. Added tests.
