### PR TITLE
Don't leak global variables inside a closure

### DIFF
--- a/source/class.js
+++ b/source/class.js
@@ -10,7 +10,7 @@
   this.Class = function(){};
  
   // Create a new Class that inherits from this class
-  Class.extend = function(prop) {
+  this.Class.extend = function(prop) {
     var _super = this.prototype;
    
     // Instantiate a base class (but only create the instance,
@@ -61,5 +61,5 @@
    
     return Class;
   };
-})();
+}).call(Liquid);
 

--- a/source/condition.js
+++ b/source/condition.js
@@ -1,4 +1,4 @@
-Liquid.Condition = Class.extend({
+Liquid.Condition = Liquid.Class.extend({
 
   init: function(left, operator, right) {
     this.left = left;

--- a/source/context.js
+++ b/source/context.js
@@ -1,4 +1,4 @@
-Liquid.Context = Class.extend({
+Liquid.Context = Liquid.Class.extend({
 
   init: function(assigns, registers, rethrowErrors) {
     this.scopes = [ assigns ? assigns : {} ];

--- a/source/core.js
+++ b/source/core.js
@@ -35,13 +35,9 @@ var Liquid = {
 //= require <strftime>
 //= require <split>
 
-var root = this;
-
 if (typeof exports !== 'undefined') {
   if (typeof module !== 'undefined' && module.exports) {
     exports = module.exports = Liquid;
   }
   exports.Liquid = Liquid;
-} else {
-  root['Liquid'] = Liquid;
 }

--- a/source/drop.js
+++ b/source/drop.js
@@ -1,4 +1,4 @@
-Liquid.Drop = Class.extend({
+Liquid.Drop = Liquid.Class.extend({
   setContext: function(context) {
     this.context = context;
   },

--- a/source/strainer.js
+++ b/source/strainer.js
@@ -1,4 +1,4 @@
-Liquid.Strainer = Class.extend({
+Liquid.Strainer = Liquid.Class.extend({
 
   init: function(context) {
     this.context = context;

--- a/source/tag.js
+++ b/source/tag.js
@@ -1,4 +1,4 @@
-Liquid.Tag = Class.extend({
+Liquid.Tag = Liquid.Class.extend({
 
   init: function(tagName, markup, tokens) {
     this.tagName = tagName;

--- a/source/template.js
+++ b/source/template.js
@@ -1,4 +1,4 @@
-Liquid.Template = Class.extend({
+Liquid.Template = Liquid.Class.extend({
 
   init: function() {
     this.root = null;

--- a/source/variable.js
+++ b/source/variable.js
@@ -1,4 +1,4 @@
-Liquid.Variable = Class.extend({
+Liquid.Variable = Liquid.Class.extend({
 
   init: function(markup) {
     this.markup = markup;


### PR DESCRIPTION
These two changes stop Liquid from leaking global variables when defined inside a closure that's called with the implicit `this` that is the global `window` object. Something like this:

    (function() {
      //= require 'liquid'
      // do some stuff with Liquid
    })();

(We include Liquid this way because we're injecting JavaScript into another page as third-party JavaScript and we don't want to clobber their variables and vice-versa.)

All the tests pass and the external API has not changed.