### PR TITLE
Fix error in PhantomJS caused by let keyword

### DIFF
--- a/source/context.js
+++ b/source/context.js
@@ -102,14 +102,14 @@ Liquid.Context = Liquid.Class.extend({
               arr   = [];
           // Check if left and right are NaN, if so try as characters
           if(isNaN(left)){
-            let varLeft = this.resolve(range[1]);
+            var varLeft = this.resolve(range[1]);
             left = parseInt(varLeft);
             if(isNaN(left)){
               throw new Error('Incorrect param for range: ' + key);
             }
           }
           if(isNaN(right)){
-            let varRight = this.resolve(range[2]);
+            var varRight = this.resolve(range[2]);
             right = parseInt(varRight);
             if(isNaN(right)){
               throw new Error('Incorrect param for range: ' + key);


### PR DESCRIPTION
This is a small one, but pulling Liquid.js into my Ember app causes issues when running the tests in PhantomJS 2.1.1 (latest).

I end up this fun error:

```
Global error: SyntaxError: Expected an identifier but found 'varLeft' instead
```

And then a bunch of stuff from Ember fails after that.

I love the new distinction between `var`, `let`, and `const`, and modern browsers seem OK with it, but unfortunately PhantomJS doesn't. :(